### PR TITLE
device: use valid dbus path for logind session

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -146,7 +146,7 @@ export class TorchDevice extends GObject.Object {
     Gio.DBusProxyFlags.NONE,
     null,
     "org.freedesktop.login1",
-    "/org/freedesktop/login1/session/self",
+    "/org/freedesktop/login1/session/auto",
     "org.freedesktop.login1.Session",
     null,
   );


### PR DESCRIPTION
fixes this issue on pmos+systemd:

```
JS ERROR: Gio.DBusError: GDBus.Error:org.freedesktop.DBus.Error.UnknownObject: Unknown object '/org/freedesktop/login1/session/self'. toggle@file:///home/clayton/.local/share/gnome-shell/extensions/torch@vixalien.com/src/device.js:132:27 set on@file:///home/clayton/.local/share/gnome-shell/extensions/torch@vixalien.com/src/device.js:61:10 @resource:///org/gnome/shell/ui/init.js:21:20
```

I'm not 100% sure this is correct, but the path it's trying to use definitely does not exist with systemd's logind.